### PR TITLE
Updated catalog-file

### DIFF
--- a/battery.ttl
+++ b/battery.ttl
@@ -13,7 +13,7 @@
 
 <http://emmo.info/battery/battery> rdf:type owl:Ontology ;
                                     owl:versionIRI <http://emmo.info/battery/0.5.0/battery> ;
-                                    owl:imports <http://emmo.info/battery/0.5.0/batteryquantities.ttl> ,
+                                    owl:imports <http://emmo.info/battery/0.5.0/batteryquantities> ,
                                                 <http://emmo.info/electrochemistry/0.5.0/electrochemistry> ;
                                     dcterms:abstract """A toplevel battery interface domain ontology based on EMMO.
 

--- a/batteryquantities.ttl
+++ b/batteryquantities.ttl
@@ -12,8 +12,8 @@
 @base <http://emmo.info/battery/batteryquantities> .
 
 <http://emmo.info/battery/batteryquantities> rdf:type owl:Ontology ;
-                                              owl:versionIRI <http://emmo.info/battery/0.5.0/batteryquantities.ttl> ;
-                                              owl:imports <http://emmo.info/electrochemistry/0.5.0/electrochemicalquantities.ttl> ;
+                                              owl:versionIRI <http://emmo.info/battery/0.5.0/batteryquantities> ;
+                                              owl:imports <http://emmo.info/electrochemistry/0.5.0/electrochemicalquantities> ;
                                               dcterms:abstract """Common properties for batteries and their interfaces.
 
 Released under the Creative Commons license Attribution 4.0 International (CC BY 4.0)."""@en ;

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
 <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
-	<uri name="http://emmo.info/battery/0.5.0/batttery"    				uri="./battery.ttl"/>
-	<uri name="http://emmo.info/battery/0.5.0/battteryquantities"    		uri="./batteryquantities.ttl"/>
+	<uri name="http://emmo.info/battery/0.5.0/battery"    				uri="./battery.ttl"/>
+	<uri name="http://emmo.info/battery/0.5.0/batteryquantities"    		uri="./batteryquantities.ttl"/>
 
 	<uri name="http://emmo.info/electrochemistry/0.5.0/electrochemistry"            uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemistry.ttl"/>
 	<uri name="http://emmo.info/electrochemistry/0.5.0/electrochemicalquantities"            uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemicalquantities.ttl"/>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-   <uri id="Imports Wizard Entry" name="http://emmo.info/material/0.1.0/material" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/material_bigmap_temp.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/temp/unitsextension_bigmap" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/unitsextension_bigmap.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/temp/isq_big_map" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/isq_bigmap.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4" uri="https://emmo-repo.github.io/versions/1.0.0-beta4/emmo-inferred.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/electrochemistry/0.5.0/electrochemicalquantities.ttl" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemicalquantities.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/electrochemistry/0.5.0/electrochemistry" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemistry.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/battery/0.5.0/batteryquantities.ttl" uri="https://raw.githubusercontent.com/emmo-repo/domain-battery/master/batteryquantities.ttl"/>
-    <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
-        <uri name="https://raw.githubusercontent.com/emmo-repo/domain-battery/master/battery.ttl" uri="battery.ttl"/>
-        <uri name="https://raw.githubusercontent.com/emmo-repo/domain-battery/master/batteryquantities.ttl" uri="batteryquantities.ttl"/>
-        <!-- <uri name="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemistry.ttl" uri="electrochemistry.ttl"/> -->
-        <!-- <uri name="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemicalquantities.ttl" uri="electrochemicalquantities.ttl"/> -->
+<group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
+	<uri name="http://emmo.info/battery/0.5.0/batttery"    				uri="./battery.ttl"/>
+	<uri name="http://emmo.info/battery/0.5.0/battteryquantities"    		uri="./batteryquantities.ttl"/>
+
+	<uri name="http://emmo.info/electrochemistry/0.5.0/electrochemistry"            uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemistry.ttl"/>
+	<uri name="http://emmo.info/electrochemistry/0.5.0/electrochemicalquantities"            uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemicalquantities.ttl"/>
+
+        <!-- The uris below should be removed when EMMOntoPy reads catalog files for imported ontologies correctly. -->
+        <!-- All the ontologies below are imported from electrochemistry and not directly from here.-->
+	<uri name="http://emmo.info/emmo/1.0.0-beta4"                                    uri="https://raw.githubusercontent.com/emmo-repo/emmo-repo.github.io/master/versions/1.0.0-beta4/emmo-inferred.ttl"/>
+        <uri name="http://emmo.info/emmo/1.0.0-beta4/temp/isq_bigmap"                   uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/isq_bigmap.ttl"/>
+        <uri name="http://emmo.info/emmo/1.0.0-beta4/temp/unitsextension_bigmap"         uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/unitsextension_bigmap.ttl"/>
+        <uri name="http://emmo.info/material/0.1.0/material"                             uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/material_bigmap_temp.ttl"/>
     </group>
 </catalog>


### PR DESCRIPTION
Imported ontologies from imported ontologies are included in the current catalog file, as a fix is required in EMMOntoPy.

Note that tests still fail, but now at a later stage, not on import of subontologies.