### PR TITLE
addresses docs bug: class index link broken

### DIFF
--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -60,7 +60,7 @@ Check out these resources to get started!
         Let's go! Here is some information to help you get started
 
     .. grid-item-card::
-        :link: electrochemistry.html
+        :link: battery.html
 
         :octicon:`book;1em;sd-text-info`  Class Index
         ^^^^^^^^^^^


### PR DESCRIPTION
Addresses issue https://github.com/BIG-MAP/BattINFO/issues/114#issue-2154485888 which was the same case for the battery docs